### PR TITLE
日本語対応実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ gem 'active_hash'
 gem 'pry-rails'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails-i18n (7.0.6)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6.1)
       actionpack (= 6.0.6.1)
       activesupport (= 6.0.6.1)
@@ -380,6 +383,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails
   rubocop
   sass-rails (~> 5)

--- a/app/models/order_delivery.rb
+++ b/app/models/order_delivery.rb
@@ -5,13 +5,13 @@ class OrderDelivery
   with_options presence: true do
     validates :item_id
     validates :user_id
-    validates :postcode, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+    validates :postcode, format: {with: /\A[0-9]{3}-[0-9]{4}\z/}
     validates :city
     validates :block
     validates :phone, format: {with: /\A\d{10,11}\z/ }
     validates :token
   end
-  validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
+  validates :prefecture_id, numericality: {other_than: 1}
 
   def save
     order = Order.create(item_id: item_id, user_id: user_id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Furima38925
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,30 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: お名前(姓）
+        first_name: お名前(名）
+        last_name_kana: お名前カナ(姓）
+        first_name_kana: お名前カナ(名）
+        birthday: 生年月日
+      item:
+        image: 画像
+        product: 商品名
+        content: 商品の説明
+        category_id: カテゴリー
+        status_id: 商品の状態
+        charge_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        preparation_id: 発送までの日数
+        price: 価格
+
+  activemodel:
+    attributes:        
+      order_delivery:
+        postcode: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        block: 番地
+        phone: 電話番号
+        token: カード情報

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,72 +15,72 @@ RSpec.describe Item, type: :model do
       it 'productが空では保存できない' do
         @item.product = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
       it 'contentが空では保存できない' do
         @item.content = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Content can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
       it 'priceが空では保存できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("価格を入力してください")
       end
       it 'imageが空では保存できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("画像を入力してください")
       end
       it 'categoryが「---」では保存できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include("カテゴリーは1以外の値にしてください")
       end
       it 'statusが「---」では保存できない' do
         @item.status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status must be other than 1")
+        expect(@item.errors.full_messages).to include("商品の状態は1以外の値にしてください")
       end
       it 'chargeが「---」では保存できない' do
         @item.charge_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Charge must be other than 1")
+        expect(@item.errors.full_messages).to include("配送料の負担は1以外の値にしてください")
       end
       it 'prefectureが「---」では保存できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include("発送元の地域は1以外の値にしてください")
       end
       it 'preparationが「---」では保存できない' do
         @item.preparation_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Preparation must be other than 1")
+        expect(@item.errors.full_messages).to include("発送までの日数は1以外の値にしてください")
       end
       it 'priceが正の少数では保存できない' do
         @item.price = Faker::Number.between(from: 300.0, to: 9999999.0)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be an integer")
+        expect(@item.errors.full_messages).to include("価格は整数で入力してください")
       end
       it 'priceが1以上、299以下の整数では保存できない' do
         @item.price = Faker::Number.between(from: 1, to: 299)
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include("価格は300以上の値にしてください")
       end
       it 'priceが0以下では保存できない' do
         @item.price = -1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include("価格は不正な値です")
       end
       it 'priceが10,000,000以上では保存できない' do
         @item.price = 10000000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include("価格は9999999以下の値にしてください")
       end
       it 'userが紐付いていないと保存できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        expect(@item.errors.full_messages).to include('Userを入力してください')
       end
     end
   end

--- a/spec/models/order_delivery_spec.rb
+++ b/spec/models/order_delivery_spec.rb
@@ -23,67 +23,67 @@ RSpec.describe OrderDelivery, type: :model do
       it 'postcodeが空だと保存できないこと' do
         @order_delivery.postcode = ''
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Postcode can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("郵便番号を入力してください")
       end
       it 'postcodeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
         @order_delivery.postcode = '1234567'
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include('Postcode is invalid. Include hyphen(-)')
+        expect(@order_delivery.errors.full_messages).to include('郵便番号は不正な値です')
       end
       it 'prefectureを選択していないと保存できないこと' do
         @order_delivery.prefecture_id = 1
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("都道府県は1以外の値にしてください")
       end
       it 'cityが空だと保存できないこと' do
         @order_delivery.city = ''
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("City can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("市区町村を入力してください")
       end
       it 'blockが空だと保存できないこと' do
         @order_delivery.block = ''
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Block can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("番地を入力してください")
       end
       it 'phoneが空だと保存できないこと' do
         @order_delivery.phone = ''
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Phone can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("電話番号を入力してください")
       end
       it 'phoneが半角のハイフンを含んだ形式では保存できないこと' do
         @order_delivery.phone = '111-1111-1111'
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Phone is invalid")
+        expect(@order_delivery.errors.full_messages).to include("電話番号は不正な値です")
       end
       it 'phoneが全角数字だと保存できないこと' do
         @order_delivery.phone = '１１１１１１１１１１１'
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include('Phone is invalid')
+        expect(@order_delivery.errors.full_messages).to include('電話番号は不正な値です')
       end
       it 'phoneが9桁以下だと保存できないこと' do
         @order_delivery.phone = '111111111'
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include('Phone is invalid')
+        expect(@order_delivery.errors.full_messages).to include('電話番号は不正な値です')
       end
       it 'phoneが12桁以上だと保存できないこと' do
         @order_delivery.phone = '111111111111'
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include('Phone is invalid')
+        expect(@order_delivery.errors.full_messages).to include('電話番号は不正な値です')
       end
       it 'userが紐付いていないと保存できないこと' do
         @order_delivery.user_id = nil
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("User can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("Userを入力してください")
       end
       it 'itemが紐付いていないと保存できないこと' do
         @order_delivery.item_id = nil
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Item can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("Itemを入力してください")
       end
       it "tokenが空では登録できないこと" do
         @order_delivery.token = nil
         @order_delivery.valid?
-        expect(@order_delivery.errors.full_messages).to include("Token can't be blank")
+        expect(@order_delivery.errors.full_messages).to include("カード情報を入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,139 +15,139 @@ RSpec.describe User, type: :model do
       it "nicknameが空では登録できない" do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it "emailが空では登録できない" do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
       it "passwordが空では登録できない" do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it "last_nameが空では登録できない" do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("お名前(姓）を入力してください")
       end
       it "first_nameが空では登録できない" do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("お名前(名）を入力してください")
       end
       it "last_name_kanaが空では登録できない" do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+        expect(@user.errors.full_messages).to include("お名前カナ(姓）を入力してください")
       end
       it "first_name_kanaが空では登録できない" do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name kana can't be blank")
+        expect(@user.errors.full_messages).to include("お名前カナ(名）を入力してください")
       end
       it "birthdayが空では登録できない" do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
       it '重複したemailが存在する場合は登録できない' do
         @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
       it 'emailは@を含まないと登録できない' do
         @user.email = 'testmail'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = '123ab'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
       it 'passwordが129文字以上では登録できない' do
         @user.password = Faker::Alphanumeric.alphanumeric(number: 129, min_alpha: 1, min_numeric: 1)
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too long (maximum is 128 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは128文字以内で入力してください')
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
         @user.password = '123456a'
         @user.password_confirmation = '123456b'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
       it 'passwordが半角英字のみでは登録できない' do
         @user.password = 'aaaaaaaa'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include('パスワードは不正な値です')
       end
       it 'passwordが半角数字のみでは登録できない' do
         @user.password = '11111111'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include('パスワードは不正な値です')
       end
       it 'passwordに全角英字が含まれると登録できない' do
         @user.password = '111111aA'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include('パスワードは不正な値です')
       end
       it 'last_nameに英字が含まれると登録できない' do
         @user.last_name = '山田a'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name is invalid')
+        expect(@user.errors.full_messages).to include('お名前(姓）は不正な値です')
       end
       it 'first_nameに英字が含まれると登録できない' do
         @user.first_name = 'メアリーじゅんb'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name is invalid')
+        expect(@user.errors.full_messages).to include('お名前(名）は不正な値です')
       end
       it 'last_name_kanaに英字が含まれると登録できない' do
         @user.last_name_kana = 'ヤマダa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(姓）は不正な値です')
       end
       it 'last_name_kanaにひらがなが含まれると登録できない' do
         @user.last_name_kana = 'ヤマダあ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(姓）は不正な値です')
       end
       it 'last_name_kanaに漢字が含まれると登録できない' do
         @user.last_name_kana = 'ヤマダ山'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(姓）は不正な値です')
       end
       it 'last_name_kanaに半角カナが含まれると登録できない' do
         @user.last_name_kana = 'ヤマダｱ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(姓）は不正な値です')
       end
       it 'first_name_kanaに英字が含まれると登録できない' do
         @user.first_name_kana = 'メアリージュンa'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(名）は不正な値です')
       end
       it 'first_name_kanaにひらがなが含まれると登録できない' do
         @user.first_name_kana = 'メアリージュンあ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(名）は不正な値です')
       end
       it 'first_name_kanaに漢字が含まれると登録できない' do
         @user.first_name_kana = 'メアリージュン山'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(名）は不正な値です')
       end
       it 'first_name_kanaに半角カナが含まれると登録できない' do
         @user.first_name_kana = 'メアリージュンｱ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name kana is invalid')
+        expect(@user.errors.full_messages).to include('お名前カナ(名）は不正な値です')
       end
     end
   end


### PR DESCRIPTION
# what
- 新規登録のエラーメッセージが日本語表記されるようにする
- ログインのエラーメッセージが日本語表記されるようにする
- 商品出品のエラーメッセージが日本語表記されるようにする
- 商品編集のエラーメッセージが日本語表記されるようにする
- 商品購入のエラーメッセージが日本語表記されるようにする
# why
エラーメッセージの日本語対応実装